### PR TITLE
Murmurhash Functor, khset32_t

### DIFF
--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -40,7 +40,7 @@ using namespace kraken;
 #ifdef EXACT_COUNTING
   #ifdef USE_KHSET_FOR_EXACT_COUNTING
     #include "khset.h"
-    using READCOUNTS = ReadCounts< khset64_t >;
+    using READCOUNTS = ReadCounts< kh::khset64_t >;
   #else
     #include <unordered_set>
     using READCOUNTS = ReadCounts< unordered_set<uint64_t> >;

--- a/src/count_unique.cpp
+++ b/src/count_unique.cpp
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
   uint64_t ctr = 0;
   
   unordered_set<uint64_t> exact_counter;
-  khset64_t exact_counter_khash;
+  kh::khset64_t exact_counter_khash;
 
   if (use_stdin) {
     uint64_t nr;
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
     std::uniform_int_distribution<uint64_t> distr;
     for (size_t j = 0; j < n_redo; ++j) {
       unordered_set<uint64_t> exact_counter1;
-      khset64_t exact_counter_khash1;
+      kh::khset64_t exact_counter_khash1;
       for(size_t i = 0; i < n_rand; i++) {
         if (exact_counting_unordered_set) {
             exact_counter1.insert(distr(rng));

--- a/src/hyperloglogplus.cpp
+++ b/src/hyperloglogplus.cpp
@@ -467,8 +467,8 @@ HyperLogLogPlusMinus<HASH>& HyperLogLogPlusMinus<HASH>::operator= (const HyperLo
 template<typename HASH>
 HyperLogLogPlusMinus<HASH>::HyperLogLogPlusMinus(const HyperLogLogPlusMinus<HASH>& other):
       p(other.p), m(other.m), 
-      M(other.M), n_observed(other.n_observed), sparse(other.sparse), 
-      sparseList(other.sparseList), bit_mixer() {
+      M(other.M), n_observed(other.n_observed), sparse(other.sparse), bit_mixer(),
+      sparseList(other.sparseList) {
 }
 
 

--- a/src/hyperloglogplus.cpp
+++ b/src/hyperloglogplus.cpp
@@ -425,8 +425,8 @@ double tau(double x) {
 // HyperLogLogPlusMinus class methods
 
 template<>
-HyperLogLogPlusMinus<uint64_t>::HyperLogLogPlusMinus(uint8_t precision, bool sparse, uint64_t  (*bit_mixer) (uint64_t)):
-      p(precision), m(1<<precision), sparse(sparse), bit_mixer(bit_mixer) {
+HyperLogLogPlusMinus<uint64_t>::HyperLogLogPlusMinus(uint8_t precision, bool sparse):
+      p(precision), m(1<<precision), sparse(sparse), bit_mixer() {
     if (precision > 18 || precision < 4) {
           throw std::invalid_argument("precision (number of register = 2^precision) must be between 4 and 18");
     }
@@ -447,7 +447,6 @@ HyperLogLogPlusMinus<HASH>& HyperLogLogPlusMinus<HASH>::operator= (HyperLogLogPl
   n_observed = other.n_observed;
   sparse = other.sparse;
   sparseList = std::move(other.sparseList);
-  bit_mixer = other.bit_mixer;
   return *this;
 }
 
@@ -459,7 +458,6 @@ HyperLogLogPlusMinus<HASH>& HyperLogLogPlusMinus<HASH>::operator= (const HyperLo
   n_observed = other.n_observed;
   sparse = other.sparse;
   sparseList = other.sparseList;
-  bit_mixer = other.bit_mixer;
   return *this;
 }
 
@@ -467,8 +465,7 @@ template<typename HASH>
 HyperLogLogPlusMinus<HASH>::HyperLogLogPlusMinus(const HyperLogLogPlusMinus<HASH>& other):
       p(other.p), m(other.m), 
       M(other.M), n_observed(other.n_observed), sparse(other.sparse), 
-      sparseList(other.sparseList), 
-      bit_mixer(other.bit_mixer) {
+      sparseList(other.sparseList), bit_mixer() {
 }
 
 
@@ -477,8 +474,7 @@ HyperLogLogPlusMinus<HASH>::HyperLogLogPlusMinus(HyperLogLogPlusMinus<HASH>&& ot
       p(other.p), m(other.m), 
       M(std::move(other.M)), 
       n_observed(other.n_observed), sparse(other.sparse), 
-      sparseList(std::move(other.sparseList)), 
-      bit_mixer(other.bit_mixer) {
+      sparseList(std::move(other.sparseList)), bit_mixer() {
 }
 
 

--- a/src/hyperloglogplus.cpp
+++ b/src/hyperloglogplus.cpp
@@ -62,6 +62,10 @@ static int clz_manual(uint64_t x)
 #define __builtin_clz(x) __lzcnt(x)
 #define __builtin_clzl(x) __lzcnt64(x)
 #endif
+template<typename Func> void for_each(kh::khset32_t &set, const Func &func) {set.for_each(func);}
+template<typename Func> void for_each(const kh::khset32_t &set, const Func &func) {set.for_each(func);}
+template<typename Func> void for_each(std::unordered_set<uint32_t> &set, const Func &func) {for(auto &x: set) func(x);}
+template<typename Func> void for_each(const std::unordered_set<uint32_t> &set, const Func &func) {for(const auto &x: set) func(x);}
 
 inline uint8_t clz(const uint32_t x, const uint8_t max = 32) {
   if (x == 0) { return max; }
@@ -353,14 +357,14 @@ vector<int> registerHistogram(const vector<uint8_t>& M, uint8_t q) {
     return C;
 }
 
+
 vector<int> sparseRegisterHistogram(const SparseListType& sparseList, uint8_t pPrime, uint8_t p, uint8_t q){
     vector<int> C(q+2, 0);
     size_t m = 1 << pPrime;
-    for (const auto& encoded_hash_value : sparseList) {
-      uint8_t rank_val = getEncodedRank(encoded_hash_value, pPrime, p);
-      ++C[rank_val]; 
-      --m;
-    }
+    for_each(sparseList, [&](uint32_t v) {
+        ++C[getEncodedRank(v, pPrime, p)];
+        --m;
+    });
     C[0] = m;
     return C;
 }
@@ -426,13 +430,12 @@ double tau(double x) {
 
 template<>
 HyperLogLogPlusMinus<uint64_t>::HyperLogLogPlusMinus(uint8_t precision, bool sparse):
-      p(precision), m(1<<precision), sparse(sparse), bit_mixer() {
+      p(precision), m(1<<precision), sparse(sparse), bit_mixer(), sparseList(SparseListType()) {
     if (precision > 18 || precision < 4) {
           throw std::invalid_argument("precision (number of register = 2^precision) must be between 4 and 18");
     }
 
     if (sparse) {
-      this->sparseList = SparseListType(); // TODO: if SparseListType is changed, initialize with appropriate size
       this->sparseList.reserve(m/4);
     } else {
       this->M = vector<uint8_t>(m);
@@ -446,7 +449,7 @@ HyperLogLogPlusMinus<HASH>& HyperLogLogPlusMinus<HASH>::operator= (HyperLogLogPl
   M = std::move(other.M);
   n_observed = other.n_observed;
   sparse = other.sparse;
-  sparseList = std::move(other.sparseList);
+  //sparseList = std::move(other.sparseList);
   return *this;
 }
 
@@ -474,7 +477,9 @@ HyperLogLogPlusMinus<HASH>::HyperLogLogPlusMinus(HyperLogLogPlusMinus<HASH>&& ot
       p(other.p), m(other.m), 
       M(std::move(other.M)), 
       n_observed(other.n_observed), sparse(other.sparse), 
-      sparseList(std::move(other.sparseList)), bit_mixer() {
+      bit_mixer(),
+      sparseList(std::move(other.sparseList))
+{
 }
 
 
@@ -551,6 +556,7 @@ void HyperLogLogPlusMinus<T>::switchToNormalRepresentation() {
 #endif
 }
 
+
 // add sparseList to the registers of M
 template<typename T>
 void HyperLogLogPlusMinus<T>::addToRegisters(const SparseListType &sparseList) {
@@ -561,15 +567,14 @@ void HyperLogLogPlusMinus<T>::addToRegisters(const SparseListType &sparseList) {
     if (sparseList.size() == 0) {
       return;
     }
-    for (auto encoded_hash_value_ptr = sparseList.begin(); encoded_hash_value_ptr != sparseList.end(); ++encoded_hash_value_ptr) {
-
-      size_t idx = getIndex(*encoded_hash_value_ptr, p);
+    for_each(sparseList, [this](uint32_t v) {
+      size_t idx = getIndex(v, p);
       assert_lt(idx,M.size());
-      uint8_t rank_val = getEncodedRank(*encoded_hash_value_ptr, pPrime, p);
+      uint8_t rank_val = getEncodedRank(v, pPrime, p);
       if (rank_val > this->M[idx]) {
         this->M[idx] = rank_val;
       }
-    }
+    });
 }
 
 
@@ -597,7 +602,8 @@ void HyperLogLogPlusMinus<T>::merge(HyperLogLogPlusMinus<T>&& other) {
       if (this->sparse && other.sparse) {
         // this->merge(static_cast<const HyperLogLogPlusMinus<T>&>(other));
         // consider using addHashToSparseList(this->sparseList, val, pPrime) and checking for sizes
-        this->sparseList.insert(other.sparseList.begin(), other.sparseList.end());
+        //this->sparseList.insert(other.sparseList.begin(), other.sparseList.end());
+        for_each(other.sparseList, [this](uint32_t v) {sparseList.insert(v);});
       } else if (other.sparse) {
         // other is sparse, but this is not
         addToRegisters(other.sparseList);
@@ -638,7 +644,8 @@ void HyperLogLogPlusMinus<T>::merge(const HyperLogLogPlusMinus<T>& other) {
       n_observed += other.n_observed;
       if (this->sparse && other.sparse) {
         // consider using addHashToSparseList(this->sparseList, val, pPrime) and checking for sizes
-        this->sparseList.insert(other.sparseList.begin(), other.sparseList.end());
+        //this->sparseList.insert(other.sparseList.begin(), other.sparseList.end());
+        for_each(other.sparseList, [this](uint32_t v) {sparseList.insert(v);});
       } else if (other.sparse) {
         // other is sparse, but this is not
         addToRegisters(other.sparseList);
@@ -681,14 +688,14 @@ uint64_t HyperLogLogPlusMinus<uint64_t>::flajoletCardinality(bool use_sparse_pre
       } else{
         // For testing purposes. Put sparse list into a standard register
         M = vector<uint8_t>(m, 0);
-        for (const auto& val : sparseList) {
+        for_each(sparseList, [&](uint32_t val) {
           size_t idx = getIndex(val, p);
           assert_lt(idx,M.size());
           uint8_t rank_val = getEncodedRank(val, pPrime, p);
           if (rank_val > M[idx]) {
             M[idx] = rank_val;
           }
-        }
+        }); // for_each
       }
     }
     double est = calculateRawEstimate(M);

--- a/src/hyperloglogplus.cpp
+++ b/src/hyperloglogplus.cpp
@@ -449,7 +449,7 @@ HyperLogLogPlusMinus<HASH>& HyperLogLogPlusMinus<HASH>::operator= (HyperLogLogPl
   M = std::move(other.M);
   n_observed = other.n_observed;
   sparse = other.sparse;
-  //sparseList = std::move(other.sparseList);
+  sparseList = std::move(other.sparseList);
   return *this;
 }
 

--- a/src/hyperloglogplus.hpp
+++ b/src/hyperloglogplus.hpp
@@ -27,6 +27,7 @@
 
 #include<vector>
 #include<unordered_set>
+#include "khset.h"
 using namespace std;
 
 //#define HLL_DEBUG
@@ -44,7 +45,11 @@ uint64_t murmurhash3_finalizer (uint64_t key);
 
 // Heule et al. encode the sparse list with variable length encoding
 //   see section 5.3.2. This implementation just uses a sorted vector or unordered_set.
+#if USE_SLOW_UNORDERED_SET
 typedef unordered_set<uint32_t> SparseListType;
+#else
+using SparseListType = kh::khset32_t;
+#endif
 // Other possible SparseList types:
 // // typedef vector<uint32_t> SparseListType;
 // The sorted vector implementation is pretty inefficient currently, as the vector
@@ -73,8 +78,8 @@ private:
   uint64_t n_observed = 0;
 
   bool sparse;          // sparse representation of the data?
-  SparseListType sparseList;
   const Murmur3Finalizer bit_mixer;
+  SparseListType sparseList;
 
   // sparse versions of p and m
   static const uint8_t  pPrime = 25; // precision when using a sparse representation 
@@ -124,5 +129,6 @@ private:
   void addToRegisters(const SparseListType &sparseList);
 
 };
+
 
 #endif /* HYPERLOGLOGPLUS_H_ */

--- a/src/hyperloglogplus.hpp
+++ b/src/hyperloglogplus.hpp
@@ -57,6 +57,12 @@ typedef unordered_set<uint32_t> SparseListType;
  * HyperLogLogPlusMinus class for counting the number of unique 64-bit values in stream
  * Note that only HASH=uint64_t is implemented.
  */
+
+
+struct Murmur3Finalizer {
+    uint64_t operator()(uint64_t v) const {return murmurhash3_finalizer(v);}
+};
+
 template<typename HASH>
 class HyperLogLogPlusMinus {
 
@@ -68,7 +74,7 @@ private:
 
   bool sparse;          // sparse representation of the data?
   SparseListType sparseList;
-  HASH (*bit_mixer) (uint64_t);
+  const Murmur3Finalizer bit_mixer;
 
   // sparse versions of p and m
   static const uint8_t  pPrime = 25; // precision when using a sparse representation 
@@ -82,7 +88,7 @@ public:
   bool use_n_observed = true; // return min(estimate, n_observed) instead of estimate
 
   // Construct HLL with precision bits
-  HyperLogLogPlusMinus(uint8_t precision=12, bool sparse=true, HASH (*bit_mixer) (uint64_t) = murmurhash3_finalizer);
+  HyperLogLogPlusMinus(uint8_t precision=12, bool sparse=true);
   HyperLogLogPlusMinus(const HyperLogLogPlusMinus<HASH>& other);
   HyperLogLogPlusMinus(HyperLogLogPlusMinus<HASH>&& other);
   HyperLogLogPlusMinus<HASH>& operator= (HyperLogLogPlusMinus<HASH>&& other);

--- a/src/khset.h
+++ b/src/khset.h
@@ -93,6 +93,10 @@ struct is_map<std::unordered_map<Key, T, Hash, Compare, Allocator>> {static cons
                 func(this->keys[ki]);\
     }
 
+#if __GCC__
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic push
+#endif
 
 // Steal everything, take no prisoners.
 #define KH_MOVE_DEC(t) \
@@ -156,7 +160,8 @@ struct khset##nbits##_t: EmptyKhSet, khash_t(name) {\
     }\
     khiter_t get(u##nbits x) const {return kh_get(name, this, x);}\
     void erase(u##nbits val) {\
-        if(auto it = get(val); it != capacity())\
+        auto it = get(val);\
+        if(it != capacity())\
             kh_del(name, this, it);\
     }\
     template<typename ItType, typename ItType2>\
@@ -206,7 +211,7 @@ struct khset_cstr_t: EmptyKhSet, khash_t(cs) {
         return kh_get(cs, this, s);
     }
     void del(const char *s) {
-        if(auto it = get(s); it != capacity()) std::free(const_cast<char *>(this->keys[it]));
+        auto it = get(s); if(it != capacity()) std::free(const_cast<char *>(this->keys[it]));
     }
     khiter_t insert(const char *s) {return this->insert(s, std::strlen(s));}
     khiter_t insert(const char *s, size_t l) {
@@ -326,6 +331,10 @@ template<typename T> T&operator+=(T &a, const T &b) {
 
 #undef KH_MOVE_DEC
 #undef KH_COPY_DEC
+
+#if __GCC__
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace kh
 

--- a/src/khset.h
+++ b/src/khset.h
@@ -93,7 +93,7 @@ struct is_map<std::unordered_map<Key, T, Hash, Compare, Allocator>> {static cons
                 func(this->keys[ki]);\
     }
 
-#if __GCC__
+#ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #pragma GCC diagnostic push
 #endif
@@ -279,7 +279,7 @@ struct khmap_##name##_t: EmptyKhSet, khash_t(name) {\
             if(kh_exist(this, ki))\
                 func(this->keys[ki]);\
     }\
-    void destroy_at(khint_t ki) {throw std::runtime_error("NotImplemented");}\
+    void destroy_at(khint_t ki) {(void)ki; throw std::runtime_error("NotImplemented");}\
     void del(khint_t ki) {\
         destroy_at(ki);\
         return kh_del_##name(this, ki);\

--- a/src/khset.h
+++ b/src/khset.h
@@ -1,4 +1,23 @@
-#pragma once
+/*
+ * Copyright (c) 2018 Daniel N Baker, <dnb@jhu.edu>
+ *
+ * The file is part of KrakenUniq
+ *
+ * KrakenUniq is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KrakenUniq is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KrakenUniq.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KHSET_H__
+#define KHSET_H__
 #include <cstdint>
 #include <cstring>
 #include <type_traits>
@@ -309,3 +328,5 @@ template<typename T> T&operator+=(T &a, const T &b) {
 #undef KH_COPY_DEC
 
 } // namespace kh
+
+#endif /* #ifndef KHSET_H__ */

--- a/src/khset.h
+++ b/src/khset.h
@@ -1,35 +1,64 @@
-/* 
- * Copyright (c) 2018 Daniel N Baker, <dnb@jhu.edu>
- *
- * The file is part of KrakenUniq
- *
- * KrakenUniq is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * KrakenUniq is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
-
- * You should have received a copy of the GNU Affero General Public License
- * along with KrakenUniq.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-#ifndef KHSET_H
-#define KHSET_H
-
+#pragma once
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 #include <stdexcept>
+#include <map>
+#include <unordered_map>
+#include <set>
+#include <unordered_set>
 #include "klib/khash.h"
+
+
+namespace kh {
+
+/*
+
+Complete: khset32_t, khset64_t
+TODO: khsetstr_t
+TODO: khmap, esp w.r.t. moving objects. (This will likely require updating khash code directly.)
+
+*/
 
 KHASH_SET_INIT_INT(set)
 KHASH_SET_INIT_INT64(set64)
+KHASH_SET_INIT_STR(cs)
 
 using u32 = ::std::uint32_t;
 using u64 = ::std::uint64_t;
+
+struct EmptyKhBase {};
+struct EmptyKhSet: public EmptyKhBase {};
+struct EmptyKhMap: public EmptyKhBase {};
+
+#if __cplusplus >= 201703L
+#define CXX17_ONLY(x) x
+#define CONST_IF(x) if constexpr(x)
+#else
+#define CXX17_ONLY(x)
+#define CONST_IF(x) if(x)
+#endif
+
+#define IS_KH_DEC(kh, type) \
+template<typename T>\
+struct is_##kh {\
+    static constexpr bool value = std::is_base_of<type, T>::value;\
+};\
+CXX17_ONLY(template<typename T> inline constexpr bool is_##kh##_v = is_##kh<T>::value);
+
+IS_KH_DEC(kh, EmptyKhBase)
+IS_KH_DEC(set, EmptyKhSet)
+IS_KH_DEC(map, EmptyKhMap)
+template<typename Key, class Compare, class Allocator>
+struct is_set<std::set<Key, Compare, Allocator>> {static constexpr bool value = true;};
+template<typename Key, class Compare, class Hash, class Allocator>
+struct is_set<std::unordered_set<Key, Compare, Hash, Allocator>> {static constexpr bool value = true;};
+template<typename Key, typename T, class Compare, class Allocator>
+struct is_map<std::map<Key, T, Compare, Allocator>> {static constexpr bool value = true;};
+template<typename Key, typename T, class Hash, class Compare, class Allocator>
+struct is_map<std::unordered_map<Key, T, Hash, Compare, Allocator>> {static constexpr bool value = true;};
+#undef IS_KH_DEC
+#undef IS_KH_DEC
 
 #define __FE__ \
     template<typename Functor>\
@@ -47,16 +76,23 @@ using u64 = ::std::uint64_t;
 
 
 // Steal everything, take no prisoners.
-// re memset reinterpret_cast:
-//   khset is not trivial, so we cannot clear it with memset(3), 
-//   but zeroing objects like that is safe and should be find for our purposes 
-#define MOVE_DEC(t) \
-   t(t &&other) { \
-       std::memcpy(this, &other, sizeof(*this)); \
-       std::memset(reinterpret_cast<void*>(&other), 0, sizeof(other));\
-   }
+#define KH_MOVE_DEC(t) \
+   t(t &&other) {std::memcpy(this, &other, sizeof(*this)); std::memset(&other, 0, sizeof(other));}
 
-#define COPY_DEC(t) \
+
+#define KH_ASSIGN_DEC(t, name) \
+   t &operator=(const t &other) {\
+        reserve(other.capacity());\
+        ((khash_t(name) *)this)->size = ((khash_t(name) *)&other)->size;\
+        this->n_occupied = other.n_occupied;    \
+        this->n_buckets = other.n_buckets;    \
+        std::memcpy(flags, other.flags, __ac_fsize(other.capacity() * sizeof(uint32_t)));\
+        std::memcpy(keys, other.keys, other.capacity() * sizeof(uint32_t) * sizeof(*keys));\
+        if(other.vals) std::memcpy(vals, other.vals, other.capacity() * sizeof(uint32_t) * sizeof(*vals));\
+        return *this;\
+    }
+
+#define KH_COPY_DEC(t) \
     t(const t &other) {\
         if(other.size()) {\
             std::memcpy(this, &other, sizeof(*this));\
@@ -68,71 +104,208 @@ using u64 = ::std::uint64_t;
             flags = static_cast<u32 *>(std::malloc(memsz));\
             if(!flags) throw std::bad_alloc();\
             std::memcpy(flags, other.flags, memsz);\
+            CONST_IF(::kh::is_map<typename std::decay<decltype(*this)>::type>::value)\
+                std::memcpy(vals, other.vals, other.capacity() * sizeof(*vals));\
         } else std::memset(this, 0, sizeof(*this));\
     }
 
 
-struct khset32_t: khash_t(set) {
-    khset32_t() {std::memset(this, 0, sizeof(*this));}
-    ~khset32_t() {std::free(this->flags); std::free(this->keys);}
-    COPY_DEC(khset32_t)
-    MOVE_DEC(khset32_t)
-    // For each
-    __FE__
-    //operator khash_t(set) &() {return *reinterpret_cast<khash_t(set) *>(this);}
-    operator khash_t(set) *() {return reinterpret_cast<khash_t(set) *>(this);}
-    //operator const khash_t(set) &() const {return *reinterpret_cast<const khash_t(set) *>(this);}
-    operator const khash_t(set) *() const {return reinterpret_cast<const khash_t(set) *>(this);}
-    khash_t(set) *operator->() {return static_cast<khash_t(set) *>(*this);}
-    const khash_t(set) *operator->() const {return static_cast<const khash_t(set) *>(*this);}
-    void insert(u32 val) {
-        int khr;
-        kh_put(set, this, val, &khr);
+
+#define DECLARE_KHSET(name, nbits) \
+struct khset##nbits##_t: EmptyKhSet, khash_t(name) {\
+    khset##nbits##_t() {std::memset(this, 0, sizeof(*this));}\
+    ~khset##nbits##_t() {std::free(this->flags); std::free(this->keys);}\
+    KH_COPY_DEC(khset##nbits##_t)\
+    KH_MOVE_DEC(khset##nbits##_t)\
+    KH_ASSIGN_DEC(khset##nbits##_t, name)\
+    /* For each*/ \
+    __FE__\
+    using key_type = typename std::decay<decltype(*keys)>::type;\
+    operator khash_t(name) &() {return *reinterpret_cast<khash_t(name) *>(this);}\
+    operator khash_t(name) *() {return reinterpret_cast<khash_t(name) *>(this);}\
+    operator const khash_t(name) &() const {return *reinterpret_cast<const khash_t(name) *>(this);}\
+    operator const khash_t(name) *() const {return reinterpret_cast<const khash_t(name) *>(this);}\
+    khash_t(name) *operator->() {return static_cast<khash_t(name) *>(*this);}\
+    const khash_t(name) *operator->() const {return static_cast<const khash_t(name) *>(*this);}\
+    khset##nbits##_t &operator+=(const khset##nbits##_t &b) {\
+        b.for_each([&](key_type k){this->insert(k);});\
+        return *this;\
+    }\
+    khiter_t insert(u##nbits val) {\
+        int khr;\
+        return kh_put(name, this, val, &khr);\
+    }\
+    khiter_t get(u##nbits x) const {return kh_get(name, this, x);}\
+    void erase(u##nbits val) {\
+        if(auto it = get(val); it != capacity())\
+            kh_del(name, this, it);\
+    }\
+    template<typename ItType, typename ItType2>\
+    void insert(ItType i1, ItType2 i2) {\
+        while(i1 != i2) insert(*i1++);\
+    }\
+    void clear() {kh_clear(name, this);}\
+    bool contains(u##nbits x) const {return get(x) != kh_end(this);}\
+    size_t size() const {return kh_size(static_cast<const khash_t(name) *>(this));}\
+    size_t capacity() const {return this->n_buckets;}\
+    void reserve(size_t sz) {if(kh_resize(name, this, sz) < 0) throw std::bad_alloc();}\
+};\
+static_assert(sizeof(khset##nbits##_t) == sizeof(khash_t(name)), "Wrong size!");
+
+DECLARE_KHSET(set, 32)
+DECLARE_KHSET(set64, 64)
+#undef DECLARE_KHSET
+struct khset_cstr_t: EmptyKhSet, khash_t(cs) {
+    khset_cstr_t() {std::memset(this, 0, sizeof(*this));}
+    ~khset_cstr_t() {
+        this->for_each([](const char *s) {std::free(const_cast<char *>(s));});
+        std::free(this->flags); std::free(this->keys);
     }
-    template<typename ItType>
-    void insert(ItType i1, ItType i2) {
+    KH_COPY_DEC(khset_cstr_t)
+    KH_MOVE_DEC(khset_cstr_t)
+    /* For each*/
+    __FE__
+    operator khash_t(cs) &() {return *reinterpret_cast<khash_t(cs) *>(this);}
+    operator khash_t(cs) *() {return reinterpret_cast<khash_t(cs) *>(this);}
+    operator const khash_t(cs) &() const {return *reinterpret_cast<const khash_t(cs) *>(this);}
+    operator const khash_t(cs) *() const {return reinterpret_cast<const khash_t(cs) *>(this);}
+    khash_t(cs) *operator->() {return static_cast<khash_t(cs) *>(*this);}
+    const khash_t(cs) *operator->() const {return static_cast<const khash_t(cs) *>(*this);}
+    khiter_t insert_move(const char *s) {
+        // Takes ownership
+        int khr;
+        auto ret = kh_put(cs, this, s, &khr);
+        switch(khr) {
+            case -1: throw std::bad_alloc();
+            case 0: break; // Present: do nothing.
+            case 1: case 2: this->keys[ret] = s; break;
+            default: __builtin_unreachable();
+        }
+        return ret;
+    }
+    khiter_t get(const char *s) const {
+        return kh_get(cs, this, s);
+    }
+    void del(const char *s) {
+        if(auto it = get(s); it != capacity()) std::free(const_cast<char *>(this->keys[it]));
+    }
+    khiter_t insert(const char *s) {return this->insert(s, std::strlen(s));}
+    khiter_t insert(const char *s, size_t l) {
+        // Copies
+        int khr;
+        auto ret = kh_put(cs, this, s, &khr);
+        const char *tmp;
+        switch(khr) {
+            case -1: throw std::bad_alloc();
+            case 0: break; // Present: do nothing.
+            case 1: case 2: if((tmp = static_cast<const char *>(std::malloc(l + 1))) == nullptr) throw std::bad_alloc();
+                std::memcpy(const_cast<char *>(tmp), this->keys[ret], l);
+                this->keys[ret] = tmp;
+                const_cast<char *>(this->keys[ret])[l] = '\0';
+                break;
+            default: __builtin_unreachable();
+        }
+        return ret;
+    }
+    template<typename ItType, typename ItType2>
+    void insert(ItType i1, ItType2 i2) {
         while(i1 < i2) insert(*i1++);
     }
-    void clear() {kh_clear(set, this);}
-    bool contains(u32 x) const {return kh_get(set, this, x) != kh_end(this);}
-    size_t size() const {return kh_size(static_cast<const khash_t(set) *>(this));}
+    void clear() {kh_clear(cs, this);}
+    bool contains(const char *s) const {return kh_get(cs, this, s) != kh_end(this);}
+    size_t size() const {return kh_size(static_cast<const khash_t(cs) *>(this));}
     size_t capacity() const {return this->n_buckets;}
+    void reserve(size_t sz) {if(__builtin_expect(kh_resize(cs, this, sz) < 0, 0)) throw std::bad_alloc();}
 };
 
-struct khset64_t: khash_t(set64) {
-    khset64_t() {std::memset(this, 0, sizeof(*this));}
-    ~khset64_t() {std::free(this->flags); std::free(this->keys);}
-    COPY_DEC(khset64_t)
-    MOVE_DEC(khset64_t)
-    // For each
-    __FE__
-    //operator khash_t(set64) &() {return *reinterpret_cast<khash_t(set64) *>(this);}
-    operator khash_t(set64) *() {return reinterpret_cast<khash_t(set64) *>(this);}
-    //operator const khash_t(set64) &() const {return *reinterpret_cast<const khash_t(set64) *>(this);}
-    operator const khash_t(set64) *() const {return reinterpret_cast<const khash_t(set64) *>(this);}
-    khash_t(set64) *operator->() {return static_cast<khash_t(set64) *>(*this);}
-    const khash_t(set64) *operator->() const {return static_cast<const khash_t(set64) *>(*this);}
-    void insert(u64 val) {
-        int khr;
-        kh_put(set64, *this, val, &khr);
-    }
-    void clear() {kh_clear(set64, this);}
-    bool contains(u64 x) const {return kh_get(set64, this, x) != kh_end(this);}
-    size_t size() const {return kh_size(static_cast<const khash_t(set64) *>(this));}
-    size_t capacity() const {return this->n_buckets;}
+#define KHASH_MAP_INIT_INT32 KHASH_SET_INIT_INT
+
+/*
+Note:
+*/
+#define DECLARE_KHMAP(name, VType, init_statement, nbits) \
+\
+init_statement(name, VType)\
+struct khmap_##name##_t: EmptyKhSet, khash_t(name) {\
+    using value_type = typename std::decay<decltype(*vals)>::type;\
+    khmap_##name##_t() {std::memset(this, 0, sizeof(*this));}\
+    ~khmap_##name##_t() {\
+        CONST_IF(!std::is_trivially_destructible<value_type>::value) {\
+            /* call destructors if necessary */\
+            this->for_each_val([](value_type &v) {v.~value_type();});\
+        }\
+        std::free(this->flags); std::free(this->keys); std::free(this->vals);\
+    }\
+    KH_COPY_DEC(khmap_##name##_t)\
+    KH_MOVE_DEC(khmap_##name##_t)\
+    /* For each*/ \
+    template<typename Func>\
+    void for_each(const Func &func) {\
+        /* Give up the funk! */ \
+        /* We gotta have that funk!! */ \
+        for(khiter_t ki = 0; ki < this->n_buckets; ++ki)\
+            if(kh_exist(this, ki))\
+                func(this->keys[ki], this->vals[ki]);\
+    }\
+    template<typename Func>\
+    void for_each_key(const Func &func) {\
+        /* Give up the funk! */ \
+        /* We gotta have that funk!! */ \
+        for(khiter_t ki = 0; ki < this->n_buckets; ++ki)\
+            if(kh_exist(this, ki))\
+                func(this->keys[ki]);\
+    }\
+    void destroy_at(khint_t ki) {throw std::runtime_error("NotImplemented");}\
+    void del(khint_t ki) {\
+        destroy_at(ki);\
+        return kh_del_##name(this, ki);\
+    }\
+    template<typename Func>\
+    void for_each_val(const Func &func) {\
+        /* Give up the funk! */ \
+        /* We gotta have that funk!! */ \
+        for(khiter_t ki = 0; ki < this->n_buckets; ++ki)\
+            if(kh_exist(this, ki))\
+                func(this->vals[ki]);\
+    }\
+    void insert(u##nbits key, const VType &val) {\
+        int khr;\
+        auto ret = kh_put(name, this, key, &khr);\
+        switch(khr) {\
+            case 0: break; /* already present */ \
+            case 1: case 2: break; /* empty or deleted */ \
+            case -1: throw std::bad_alloc(); \
+            default: __builtin_unreachable();\
+        }\
+        vals[ret] = val;\
+    }\
+    \
+    operator khash_t(name) &() {return *reinterpret_cast<khash_t(name) *>(this);}\
+    operator khash_t(name) *() {return reinterpret_cast<khash_t(name) *>(this);}\
+    operator const khash_t(name) &() const {return *reinterpret_cast<const khash_t(name) *>(this);}\
+    operator const khash_t(name) *() const {return reinterpret_cast<const khash_t(name) *>(this);}\
+    khash_t(name) *operator->() {return static_cast<khash_t(name) *>(*this);}\
+    const khash_t(name) *operator->() const {return static_cast<const khash_t(name) *>(*this);}\
+    void clear() {kh_clear(name, this);}\
+    bool contains(u##nbits x) const {return kh_get(name, this, x) != kh_end(this);}\
+    size_t size() const {return kh_size(static_cast<const khash_t(name) *>(this));}\
+    size_t capacity() const {return this->n_buckets;}\
+    void reserve(size_t sz) {if(kh_resize(name, this, sz) < 0) throw std::bad_alloc();}\
 };
-#undef __FE__
-#undef COPY_DEC
-#undef MOVE_DEC
+
+#define DECLARE_KHMAP_32(name, VType) DECLARE_KHMAP(name, VType, KHASH_MAP_INIT_INT32, 32)
+#define DECLARE_KHMAP_64(name, VType) DECLARE_KHMAP(name, VType, KHASH_MAP_INIT_INT64, 64)
+
+DECLARE_KHMAP_64(64, ::std::uint64_t)
+
 
 template<typename T>
-size_t capacity(const T &a) {
-    return a.capacity();
+size_t capacity(const T &a) {return a.capacity();} // Can be specialized later.
+
+template<typename T> T&operator+=(T &a, const T &b) {
 }
 
-khset64_t&operator+=(khset64_t &a, const khset64_t &b) {
-   b.for_each([&](u64 k){a.insert(k);});
-   return a;
-}
+#undef KH_MOVE_DEC
+#undef KH_COPY_DEC
 
-#endif // ndef KHSET_H
+} // namespace kh

--- a/src/query_taxdb.cpp
+++ b/src/query_taxdb.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
   size_t optind = parse_command_line(argc, argv);
   uint32_t taxID;
 
-  for (;optind < argc; ++optind) {
+  for (;optind < static_cast<unsigned>(argc); ++optind) {
     taxID = atoll(argv[optind]);
     process_taxID(taxID);
   }


### PR DESCRIPTION
Eliminates use of function pointer for hashing and replaces `std::unordered_set<uint32_t>` with khash.