### PR TITLE
 Add option to output read classifications in same order as input 

### DIFF
--- a/scripts/krakenuniq
+++ b/scripts/krakenuniq
@@ -56,15 +56,17 @@ my $fastq_input = 0;
 my @db_prefix;
 my $threads;
 my $preload = 0;
+my $lock_memory = 0;
 my $gunzip = 0;
 my $bunzip2 = 0;
 my $paired = 0;
 my $check_names = 0;
 my $only_classified_output = 0;
-my $unclassified_out;
-my $classified_out;
-my $outfile;
-my $report_file;
+my @unclassified_outfiles;
+my @classified_outfiles;
+my @outfiles;
+my @report_outfiles;
+my @catdb_files;
 my $print_sequence = 0;
 my $uid_mapping = 0;
 my $hll_precision = 12;
@@ -77,13 +79,14 @@ GetOptions(
   "threads=i" => \$threads,
   "fasta-input" => \$fasta_input,
   "fastq-input" => \$fastq_input,
+  "lock-memory" => \$lock_memory,
   "quick" => \$quick,
   "min-hits=i" => \$min_hits,
-  "unclassified-out=s" => \$unclassified_out,
-  "classified-out=s" => \$classified_out,
+  "unclassified-out=s" => \@unclassified_outfiles,
+  "classified-out=s" => \@classified_outfiles,
+  "o|output=s" => \@outfiles,
+  "report-files=s" => \@report_outfiles,
   "print-sequence=s" => \$print_sequence,
-  "o|output=s" => \$outfile,
-  "report-file=s" => \$report_file,
   "preload" => \$preload,
   "paired" => \$paired,
   "hll-precision=i", \$hll_precision,
@@ -104,8 +107,8 @@ if (! @ARGV && !$preload) {
   usage();
 }
 
-if (!defined $report_file && !$preload && ! @ARGV) {
-  print STDERR "Need to specify a report file with --report-file! Set to 'off' to suppress report generation.
+if (!@report_outfiles && !$preload && ! @ARGV) {
+  print STDERR "Need to specify report file(s) with --report-files! Set to 'off' to suppress report generation.
 See --help for more details.\n";
   exit 1;
 }
@@ -117,7 +120,15 @@ See --help for more details.\n";
   exit 1;
 }
 
+
+my @all_db_prefix = @db_prefix;
+@db_prefix = ();
+for (@all_db_prefix) {
+    if (! -d $_) { push @catdb_files, $_}
+    else { push @db_prefix, $_}
+}
 eval { @db_prefix = map { krakenlib::find_db($_) } @db_prefix };
+
 if ($@) {
   die "$PROG: $@";
 }
@@ -147,8 +158,9 @@ if ($min_hits > 1 && ! $quick) {
   die "$PROG: --min_hits requires --quick to be specified\n";
 }
 
-if ($paired && @ARGV != 2) {
-  die "$PROG: --paired requires exactly two filenames\n";
+
+if ($paired && scalar @ARGV % 2 ) {
+    die "$PROG: --paired requires 2x filenames\n";
 }
 
 my $compressed = $gunzip || $bunzip2;
@@ -170,14 +182,23 @@ if ($auto_detect) {
   auto_detect_file_format();
 }
 
+foreach my $report_file (@report_outfiles) {
+    if (defined $report_file && !-d dirname($report_file)) {
+        print STDERR "Creating directory for $report_file.\n";
+        make_path(dirname($report_file));
+    }
 
-if (defined $report_file && !-d dirname($report_file)) {
-  print STDERR "Creating directory for $report_file.\n";
-  make_path(dirname($report_file));
+    if (defined $report_file && -s $report_file) {
+        print STDERR "Warning: Overwriting $report_file.\n";
+    }
 }
 
-if (defined $report_file && -s $report_file) {
-  print STDERR "Warning: Overwriting $report_file.\n";
+my $taxdb;
+if (scalar(@db_prefix) > 0) {
+    $taxdb = $db_prefix[0]."/taxDB";
+} else {
+    my ($filename, $dirs, $suffix) = fileparse($catdb_files[0]);
+    $taxdb = $dirs."/taxDB";
 }
 
 my $now = time();
@@ -191,27 +212,45 @@ push @flags, map { ("-d", $_) } @kdb_files;
 push @flags, map { ("-i", $_) } @idx_files;
 push @flags, "-t", $threads if $threads > 1;
 push @flags, "-q" if $quick;
+push @flags, "-l" if $lock_memory;
 push @flags, "-m", $min_hits if $min_hits > 1;
 push @flags, "-f" if $fastq_input && ! $paired;  # merger always outputs FASTA
-push @flags, "-U", $unclassified_out if defined $unclassified_out;
-push @flags, "-C", $classified_out if defined $classified_out;
-push @flags, "-o", $outfile if defined $outfile;
 push @flags, "-c", if $only_classified_output;
 push @flags, "-M" if $preload;
-push @flags, "-r", $report_file if defined $report_file;
-push @flags, "-a", $db_prefix[0]."/taxDB";
+push @flags, "-a", $taxdb;
 push @flags, "-s" if $print_sequence;
 push @flags, "-p", $hll_precision;
 if ($uid_mapping) {
   my $uid_mapping_file = "$db_prefix[0]/uid_to_taxid.map";
   if (!-f $uid_mapping_file) {
     print STDERR "Missing required file $uid_mapping_file for UID mapping.\n";
-    exit(1); 
+    exit(1);
   }
-  push @flags, "-I", $uid_mapping_file; 
+  push @flags, "-I", $uid_mapping_file;
 } else {
 
 }
+if (@outfiles) {
+    foreach my $outfile (@outfiles) {
+        push @flags, "-o", $outfile;
+    }
+}
+if (@classified_outfiles) {
+    foreach my $outfile (@classified_outfiles) {
+        push @flags, "-C", $outfile;
+    }
+}
+if (@unclassified_outfiles) {
+    foreach my $outfile (@unclassified_outfiles) {
+        push @flags, "-U", $outfile;
+    }
+}
+if (@report_outfiles) {
+    foreach my $outfile (@report_outfiles) {
+        push @flags, "-r", $outfile;
+    }
+}
+
 
 if (! -f $db_prefix[0]."/taxDB") {
   print STDERR "Taxonomy database not at ".$db_prefix[0]."/taxDB - creating it ...";
@@ -223,62 +262,55 @@ if (! -f $db_prefix[0]."/taxDB") {
   system $cmd;
 }
 
-# handle piping for decompression/merging
-my @pipe_argv;
-if ($paired) {
-  my @merge_flags;
-  push @merge_flags, "--fa" if $fasta_input;
-  push @merge_flags, "--fq" if $fastq_input;
-  push @merge_flags, "--gz" if $gunzip;
-  push @merge_flags, "--bz2" if $bunzip2;
-  push @merge_flags, "--check-names" if $check_names;
-  @pipe_argv = ($READ_MERGER, @merge_flags, @ARGV);
-}
-elsif ($compressed) {
-  if ($gunzip) {
-    @pipe_argv = ("gzip", "-dc", @ARGV);
-  }
-  elsif ($bunzip2) {
-    @pipe_argv = ("bzip2", "-dc", @ARGV);
-  }
-  else {
-    die "$PROG: unrecognized compression program! This is a Kraken bug.\n";
-  }
-}
 
-# if args exist, set up the pipe/fork/exec 
-if (@pipe_argv) {
-  pipe RD, WR;
-  my $pid = fork();
-  if ($pid < 0) {
-    die "$PROG: fork error: $!\n";
-  }
-  if ($pid) {
-    open STDIN, "<&RD"
-      or die "$PROG: can't dup stdin to read end of pipe: $!\n";
-    close RD;
-    close WR;
-    @ARGV = ("/dev/fd/0");  # make classifier read from pipe
-  }
-  else {
-    open STDOUT, ">&WR"
-      or die "$PROG: can't dup stdout to write end of pipe: $!\n";
-    close RD;
-    close WR;
-    exec @pipe_argv
-      or die "$PROG: can't exec $pipe_argv[0]: $!\n";
-  }
+# handle piping for decompression/merging
+my @pipe_argvv;
+foreach (my $i = 0; $i < @ARGV; $i++) {
+    my @pipe_argv;
+    my $use_pipe = 0;
+    if ($paired) {
+        $use_pipe = 1;
+
+        my @merge_flags;
+        push @merge_flags, "--fa" if $fasta_input;
+        push @merge_flags, "--fq" if $fastq_input;
+        push @merge_flags, "--gz" if $gunzip;
+        push @merge_flags, "--bz2" if $bunzip2;
+        push @merge_flags, "--check-names" if $check_names;
+        @pipe_argv = ("read_merger.pl", @merge_flags, @ARGV[$i, $i+1]);
+        $i++;
+    }
+    elsif ($compressed) {
+        $use_pipe = 1;
+
+        if ($gunzip) {
+            @pipe_argv = ("gzip", "-dc", $ARGV[$i]);
+        }
+        elsif ($bunzip2) {
+            @pipe_argv = ("bzip2", "-dc", $ARGV[$i]);
+        }
+        else {
+            die "$PROG: unrecognized compression program! This is a Kraken bug.\n";
+        }
+    } else {
+        @pipe_argv = $ARGV[$i];
+    }
+    if ($use_pipe) {
+        @pipe_argv = ( "<(", @pipe_argv, ")" );
+    }
+    push @pipe_argvv, @pipe_argv;
 }
 
 my $cmd = $use_exact_counting? $CLASSIFY_EXACT : $CLASSIFY;
 print STDERR "$cmd @flags @ARGV\n";
-if (defined $report_file) {
+foreach my $report_file (@report_outfiles) {
     my $mycmd = qx/ps -o args= $$/;
     open(my $RF, ">", $report_file) or die "Could not open report file for writing";
     print $RF "# KrakenUniq v#####=VERSION=##### DATE:$date DB:@db_prefix DB_SIZE:$db_size WD:$wd\n# CL:$mycmd\n";
     close($RF)
 }
-exec $cmd, @flags, @ARGV;
+
+exec join(" ", ("exec /bin/bash -c \"exec", $cmd, @flags, @pipe_argvv, "\""));
 die "$PROG: exec error: $!\n";
 
 sub usage {
@@ -319,7 +351,7 @@ Options:
 Experimental:
   --uid-mapping           Map using UID database
 
-If none of the *-input or *-compressed flags are specified, and the 
+If none of the *-input or *-compressed flags are specified, and the
 file is a regular file, automatic format detection is attempted.
 EOF
   exit $exit_code;

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,23 +11,24 @@ FOPENMP=
 endif
 
 
-CXXFLAGS = -Wall -Wextra -Wfatal-errors -pipe -O2 -std=c++11 $(FOPENMP) -I./gzstream $(NDEBUG) ${CPPFLAGS} 
-#CXXFLAGS = -Wall -std=c++11 $(FOPENMP) -O3 -Wfatal-errors
+CXXFLAGS = -Wall -Wextra -Wfatal-errors -pipe -O2 -std=c++11 $(FOPENMP) -I./gzstream $(NDEBUG) ${CPPFLAGS}
 PROGS1 = classify classifyExact db_sort set_lcas db_shrink build_taxdb read_uid_mapping count_unique dump_taxdb query_taxdb
 TEST_PROGS = grade_classification test_hll_on_db dump_db_kmers
-#PROGS = $(PROGS1) $(TEST_PROGS)
 PROGS = $(PROGS1)
-#LIBFLAGS = -L. -lz -lgzstream ${LDFLAGS}
-LIBFLAGS = -L. -lz ${LDFLAGS}
+LDFLAGS = -L.
+LDLIBS=-lz
 
-.PHONY: all install clean
+.PHONY: all install clean debug
 
 all: $(PROGS1)
+
+debug: CXXFLAGS += -g -Og
+debug: $(PROGS1)
 
 allall: $(PROGS1) $(TEST_PROGS)
 
 install: $(PROGS)
-	cp $(PROGS) $(KRAKEN_DIR)/
+	install $(PROGS) $(KRAKEN_DIR)/
 
 clean:
 	rm -rf $(PROGS) $(TEST_PROGS) *.o *.dSYM *.gch
@@ -36,13 +37,13 @@ db_shrink: krakendb.o quickfile.o
 
 db_sort: krakendb.o quickfile.o
 
-set_lcas: krakendb.o quickfile.o krakenutil.o seqreader.o uid_mapping.o
+set_lcas: set_lcas.cpp krakendb.o quickfile.o krakenutil.o seqreader.o uid_mapping.o gzstream.o
 
 grade_classification: #taxdb.hpp report-cols.hpp
 
 read_uid_mapping: quickfile.o
 
-count_unique: hyperloglogplus.o seqreader.o krakenutil.o
+count_unique: hyperloglogplus.o seqreader.o krakenutil.o gzstream.o
 
 test_count_unique: hyperloglogplus.o 
 
@@ -51,10 +52,9 @@ test_hll_on_db: krakendb.o hyperloglogplus.o quickfile.o
 dump_db_kmers: krakendb.o quickfile.o
 
 classify: classify.cpp krakendb.o quickfile.o krakenutil.o seqreader.o uid_mapping.o gzstream.o hyperloglogplus.o
-	$(CXX) $(CXXFLAGS) -o classify $^ $(LIBFLAGS)
 
 classifyExact: classify.cpp krakendb.o quickfile.o krakenutil.o seqreader.o uid_mapping.o gzstream.o hyperloglogplus.o
-	$(CXX) $(CXXFLAGS) -DEXACT_COUNTING -o classifyExact $^ $(LIBFLAGS)
+	$(CXX) $(CXXFLAGS) -DEXACT_COUNTING -o classifyExact $^ $(LDFLAGS) $(LDLIBS)
 
 query_taxdb: #taxdb.hpp
 
@@ -62,25 +62,19 @@ build_taxdb: quickfile.o #taxdb.hpp report-cols.hpp
 
 make_seqid_to_taxid_map: quickfile.o
 
-read_uid_mapping: quickfile.o krakenutil.o uid_mapping.o
+read_uid_mapping: read_uid_mapping.cpp quickfile.o krakenutil.o uid_mapping.o gzstream.o
 
-krakenutil.o: krakenutil.cpp krakenutil.hpp taxdb.hpp report-cols.hpp
-	$(CXX) $(CXXFLAGS) -c krakenutil.cpp
+krakenutil.o: krakenutil.cpp krakenutil.hpp taxdb.hpp report-cols.hpp gzstream/gzstream.h
 
 krakendb.o: krakendb.cpp krakendb.hpp quickfile.hpp
-	$(CXX) $(CXXFLAGS) -c krakendb.cpp
 
 seqreader.o: seqreader.cpp seqreader.hpp quickfile.hpp
-	$(CXX) $(CXXFLAGS) -c seqreader.cpp
 
 gzstream.o: gzstream/gzstream.C gzstream/gzstream.h
 	$(CXX) $(CXXFLAGS) -c -O gzstream/gzstream.C
 
 quickfile.o: quickfile.cpp quickfile.hpp
-	$(CXX) $(CXXFLAGS) -c quickfile.cpp
 
 uid_mapping.o: krakenutil.hpp uid_mapping.hpp uid_mapping.cpp
-	$(CXX) $(CXXFLAGS) -c uid_mapping.cpp
 
 hyperloglogplus.o: hyperloglogplus.hpp hyperloglogplus.cpp
-	$(CXX) $(CXXFLAGS) -c hyperloglogplus.cpp

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -22,10 +22,9 @@
 #include "krakendb.hpp"
 #include "krakenutil.hpp"
 #include "quickfile.hpp"
-#include "seqreader.hpp"
 #include "readcounts.hpp"
+#include "seqreader.hpp"
 #include "taxdb.hpp"
-#include "gzstream.h"
 #include "uid_mapping.hpp"
 #include <sstream>
 
@@ -49,11 +48,11 @@ using namespace kraken;
   using READCOUNTS = ReadCounts<HyperLogLogPlusMinus<uint64_t> >;
 #endif
 
-
-
 void parse_command_line(int argc, char **argv);
-void usage(int exit_code=EX_USAGE);
-void process_file(char *filename);
+void usage(int exit_code = EX_USAGE);
+void process_file(char *filename, managed_ostream &kraken_output,
+                  managed_ostream &classified_output,
+                  managed_ostream &unclassified_output);
 bool classify_sequence(DNASequence &dna, ostringstream &koss,
                        ostringstream &coss, ostringstream &uoss,
                        unordered_map<uint32_t, READCOUNTS>&);
@@ -69,6 +68,8 @@ unordered_map<uint32_t, READCOUNTS> taxon_counts; // stats per taxon
 int Num_threads = 1;
 vector<string> DB_filenames;
 vector<string> Index_filenames;
+vector<string> Onefile_DB_filenames;
+bool Lock_DB = false;
 bool Quick_mode = false;
 bool Fastq_input = false;
 bool Print_classified = false;
@@ -88,17 +89,16 @@ QuickFile UID_to_TaxID_map_file;
 
 uint32_t Minimum_hit_count = 1;
 unordered_map<uint32_t, uint32_t> Parent_map;
-unordered_map<uint32_t, vector<uint32_t> > Uid_dict;
-string Classified_output_file, Unclassified_output_file, Kraken_output_file, Report_output_file, TaxDB_file;
-ostream *Classified_output;
-ostream *Unclassified_output;
-ostream *Kraken_output;
-ostream *Report_output;
-vector<ofstream*> Open_fstreams;
-vector<ogzstream*> Open_gzstreams;
+unordered_map<uint32_t, vector<uint32_t>> Uid_dict;
+string TaxDB_file;
+
+vector<string> Kraken_output_files;
+vector<string> Report_output_files;
+vector<string> Classified_output_files;
+vector<string> Unclassified_output_files;
 size_t Work_unit_size = DEF_WORK_UNIT_SIZE;
 TaxonomyDB<uint32_t> taxdb;
-static vector<KrakenDB*> KrakenDatabases (DB_filenames.size());
+static vector<KrakenDB *> KrakenDatabases(DB_filenames.size());
 
 struct db_status {
   db_status() : current_bin_key(0), current_min_pos(1), current_max_pos(0) {}
@@ -112,30 +112,8 @@ unsigned long long total_sequences = 0;
 unsigned long long total_bases = 0;
 uint32_t ambig_taxon = -1;
 
-inline bool ends_with(std::string const & value, std::string const & ending)
-{
-        if (ending.size() > value.size()) return false;
-            return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-}
-
-ostream* cout_or_file(string file, bool append = false) {
-    if (file == "-")
-      return &cout;
-
-    if (ends_with(file, ".gz")) {
-      ogzstream* ogzs = new ogzstream(file.c_str());
-      ogzs->exceptions( ifstream::failbit | ifstream::badbit );
-      Open_gzstreams.push_back(ogzs);
-      return ogzs;
-    } else {
-      ofstream* ofs = append? new ofstream(file.c_str(), std::ofstream::app) : new ofstream(file.c_str());
-      ofs->exceptions( ifstream::failbit | ifstream::badbit );
-      Open_fstreams.push_back(ofs);
-      return ofs;
-    }
-}
-
-void loadKrakenDB(KrakenDB& database, string DB_filename, string Index_filename) {
+void load_kraken_db(KrakenDB &database, string DB_filename,
+                  string Index_filename) {
   QuickFile db_file;
   db_file.open_file(DB_filename);
   if (Populate_memory) {
@@ -151,13 +129,69 @@ void loadKrakenDB(KrakenDB& database, string DB_filename, string Index_filename)
   database.set_index(&db_index);
 }
 
+void load_onefile_krakendb(string filename, TaxonomyDB<uint32_t> &taxdb) {
+  ifstream in(filename.c_str(), ios::in | ios::binary);
+  string counts_size_s;
+  string idx_size_s;
+  string db_size_s;
+  std::getline(in, counts_size_s);
+  unsigned long long counts_size = std::stoull(counts_size_s);
+  std::getline(in, idx_size_s);
+  unsigned long long idx_size = std::stoull(idx_size_s);
+  std::getline(in, db_size_s);
+  unsigned long long db_size = std::stoull(db_size_s);
+
+  std::string counts_s(counts_size, '\0');
+  in.read(&counts_s[0], counts_size);
+  std::stringstream ss(counts_s);
+  taxdb.readGenomeSizes(ss);
+
+  char *buffer;
+  buffer = (char *)malloc(idx_size);
+  in.read(buffer, idx_size);
+  KrakenDBIndex *db_index = new KrakenDBIndex(buffer);
+
+  buffer = (char *)malloc(db_size);
+  in.read(buffer, db_size);
+  KrakenDB *database = new KrakenDB(buffer);
+  database->set_index(db_index);
+  KrakenDatabases.push_back(database);
+}
+
+void ensure_counts_file(vector<string>& db_filenames) {
+  for (size_t i = 0; i < db_filenames.size(); ++i) {
+    const auto fname = db_filenames[i] + ".counts";
+    ifstream ifs(fname);
+    bool counts_file_gd = false;
+    if (ifs.good()) {
+      if (ifs.peek() == std::ifstream::traits_type::eof()) {
+        cerr << "Kmer counts file is empty - trying to regenerate ..." <<
+          endl;
+      } else {
+        ifs.close();
+        counts_file_gd = true;
+      }
+    }
+    if (!counts_file_gd) {
+      ofstream ofs(fname);
+      cerr << "Writing kmer counts to " << fname << "... [only once for this database, may take a while] " << endl;
+      auto counts = KrakenDatabases[i]->count_taxons();
+      for (auto it = counts.begin(); it != counts.end(); ++it) {
+        ofs << it->first << '\t' << it->second << '\n';
+      }
+      ofs.close();
+    }
+    taxdb.readGenomeSizes(fname);
+  }
+}
+
 int main(int argc, char **argv) {
   #ifdef _OPENMP
   omp_set_num_threads(1);
   #endif
 
   parse_command_line(argc, argv);
-  
+
   if (Map_UIDs) {
     if (DB_filenames.size() > 1) {
       cerr << "Cannot use more than one database with UID mapping!" << endl;
@@ -171,6 +205,14 @@ int main(int argc, char **argv) {
     //if (Populate_memory) {
     UID_to_TaxID_map_file.load_file();
     //}
+  }
+
+  if (!TaxDB_file.empty()) {
+    taxdb = TaxonomyDB<uint32_t>(TaxDB_file, false);
+    Parent_map = taxdb.getParentMap();
+  } else {
+    cerr << "TaxDB argument is required!" << endl;
+    return 1;
   }
 
   if (Populate_memory)
@@ -196,6 +238,10 @@ int main(int argc, char **argv) {
     KrakenDatabases[i]->set_index(&db_indices[i]);
   }
 
+  for (size_t i = 0; i < Onefile_DB_filenames.size(); ++i) {
+    load_onefile_krakendb(Onefile_DB_filenames[i], taxdb);
+  }
+
   // TODO: Check all databases have the same k
   uint8_t kmer_size = KrakenDatabases[0]->get_k();
   for (size_t i = 1; i < KrakenDatabases.size(); ++i) {
@@ -210,127 +256,59 @@ int main(int argc, char **argv) {
   if (Populate_memory)
     cerr << "\ncomplete." << endl;
 
+  size_t n_inputs = argc - optind;
+  for (int i = optind, j = 0; i < argc; i++, j++) {
 
-  if (!TaxDB_file.empty()) {
-      taxdb = TaxonomyDB<uint32_t>(TaxDB_file, false);
-      Parent_map = taxdb.getParentMap();
-  } else {
-      cerr << "TaxDB argument is required!" << endl;
-      return 1;
-  }
+    total_classified = 0;
+    total_sequences = 0;
+    total_bases = 0;
 
-  if (Print_classified) {
-    Classified_output = cout_or_file(Classified_output_file);
-  }
+    managed_ostream classified_output(Classified_output_files[j],
+                                      Print_classified);
+    managed_ostream unclassified_output(Unclassified_output_files[j],
+                                        Print_unclassified);
+    cerr << "Writing kraken output to: " << Kraken_output_files[j] << endl;
+    managed_ostream kraken_output(Kraken_output_files[j], Print_kraken);
 
-  if (Print_unclassified) {
-    Unclassified_output = cout_or_file(Unclassified_output_file);
-  }
-
-  if (! Kraken_output_file.empty()) {
-    if (Kraken_output_file == "off" || Kraken_output_file == "-") {
-      Print_kraken = false;
-    //else if (Kraken_output_file == "-") {
-    //  Kraken_output = &cout;
-    } else {
-      cerr << "Writing Kraken output to " << Kraken_output_file << endl;
-      Kraken_output = cout_or_file(Kraken_output_file);
-    }
-  } else {
-    Kraken_output = &cout;
-  }
-
-  //cerr << "Print_kraken: " << Print_kraken << "; Print_kraken_report: " << Print_kraken_report << "; k: " << uint32_t(KrakenDatabases[0]->get_k()) << endl;
-
-  struct timeval tv1, tv2;
-  gettimeofday(&tv1, NULL);
-  for (int i = optind; i < argc; i++)
-    process_file(argv[i]);
-  gettimeofday(&tv2, NULL);
-
-  report_stats(tv1, tv2);
-
-  if (!Report_output_file.empty() && Report_output_file != "off") {
+    struct timeval tv1, tv2;
     gettimeofday(&tv1, NULL);
-    std::cerr << "Writing report file to " << Report_output_file <<"  ..\n";
-    for (size_t i = 0; i < DB_filenames.size(); ++i) {
-      const auto fname = DB_filenames[i] + ".counts";
-      ifstream ifs(fname);
-      bool counts_file_gd = false;
-      if (ifs.good()) {
-        if (ifs.peek() == std::ifstream::traits_type::eof()) {
-          cerr << "Kmer counts file is empty - trying to regenerate ..." << endl;
-        } else {
-          ifs.close();
-          counts_file_gd = true;
-        }
-      } 
-      if (!counts_file_gd) {
-        ofstream ofs(fname);
-        cerr << "Writing kmer counts to " << fname << "... [only once for this database, may take a while] " << endl;
-        auto counts = KrakenDatabases[i]->count_taxons();
-        for (auto it = counts.begin(); it != counts.end(); ++it) {
-          ofs << it->first << '\t' << it->second << '\n';
-        }
-        ofs.close();
-      }
-      taxdb.readGenomeSizes(fname);
-    }
-     Report_output = cout_or_file(Report_output_file, true);
-  
-    TaxReport<uint32_t,READCOUNTS> rep = TaxReport<uint32_t, READCOUNTS>(*Report_output, taxdb, taxon_counts, false);
-    if (HLL_PRECISION > 0) {
-      if (full_report) {
-        rep.setReportCols(vector<string> { 
-          "%",
-          "reads", 
-          "taxReads",
-          "kmers",
-          "taxKmers",
-          "kmersDB",
-          "taxKmersDB",
-          "dup",
-          "cov", 
-          "taxID", 
-          "rank", 
-          "taxName"});
-      } else {
-        rep.setReportCols(vector<string> { 
-          "%",
-          "reads", 
-          "taxReads",
-          "kmers",
-          "dup",
-          "cov", 
-          "taxID", 
-          "rank", 
-          "taxName"});
-      }
-    } else {
-      rep.setReportCols(vector<string> { 
-        "%",
-        "reads", 
-        "taxReads",
-        "taxID", 
-        "rank", 
-        "taxName"});
-    }
-    rep.printReport("kraken");
+
+    process_file(argv[i], kraken_output, classified_output,
+                 unclassified_output);
+
     gettimeofday(&tv2, NULL);
-    fprintf(stderr, "Report finished in %.3f seconds.\n", get_seconds(tv1,tv2));
-  }
-  cerr << "Finishing up ...";
+    report_stats(tv1, tv2);
 
-  for (size_t i = 0; i < Open_fstreams.size(); ++i) {
-    ofstream* ofs = Open_fstreams[i];
-    ofs->close();
-  }
+    if (Report_output_files.size() == n_inputs &&
+        !Report_output_files[j].empty() && Report_output_files[j] != "off") {
+      gettimeofday(&tv1, NULL);
+      std::cerr << "Writing report file to " << Report_output_files[j]
+                << "  ..\n";
+      managed_ostream report_output(Report_output_files[j], true, true);
 
-  for (size_t i = 0; i < Open_gzstreams.size(); ++i) {
-    ogzstream* ogzs = Open_gzstreams[i];
-    ogzs->close();
+      TaxReport<uint32_t, READCOUNTS> rep = TaxReport<uint32_t, READCOUNTS>(
+                                                                            *report_output, taxdb, taxon_counts, false);
+      if (HLL_PRECISION > 0) {
+        if (full_report) {
+          rep.setReportCols(vector<string>{
+              "%", "reads", "taxReads", "kmers", "taxKmers", "kmersDB",
+                "taxKmersDB", "dup", "cov", "taxID", "rank", "taxName"});
+        } else {
+          rep.setReportCols(vector<string>{"%", "reads", "taxReads", "kmers",
+                "dup", "cov", "taxID", "rank",
+                "taxName"});
+        }
+      } else {
+        rep.setReportCols(vector<string>{"%", "reads", "taxReads", "taxID",
+              "rank", "taxName"});
+      }
+      rep.printReport("kraken");
+      gettimeofday(&tv2, NULL);
+      fprintf(stderr, "Report finished in %.3f seconds.\n",
+              get_seconds(tv1, tv2));
+    }
   }
-
+  cerr << "Finishing up ..." << endl;
   return 0;
 }
 
@@ -363,7 +341,9 @@ void report_stats(struct timeval time1, struct timeval time2) {
           (total_sequences - total_classified) * 100.0 / total_sequences);
 }
 
-void process_file(char *filename) {
+void process_file(char *filename, managed_ostream &kraken_output,
+                  managed_ostream &classified_output,
+                  managed_ostream &unclassified_output) {
   string file_str(filename);
   DNASequenceReader *reader;
   DNASequence dna;
@@ -421,11 +401,11 @@ void process_file(char *filename) {
         }
 
         if (Print_kraken)
-          (*Kraken_output) << kraken_output_ss.str();
+          (*kraken_output) << kraken_output_ss.str();
         if (Print_classified)
-          (*Classified_output) << classified_output_ss.str();
+          (*classified_output) << classified_output_ss.str();
         if (Print_unclassified)
-          (*Unclassified_output) << unclassified_output_ss.str();
+          (*unclassified_output) << unclassified_output_ss.str();
         total_sequences += work_unit.size();
         total_bases += total_nt;
         //if (Print_Progress && total_sequences % 100000 < work_unit.size()) 
@@ -677,15 +657,22 @@ void parse_command_line(int argc, char **argv) {
 
   if (argc > 1 && strcmp(argv[1], "-h") == 0)
     usage(0);
-  while ((opt = getopt(argc, argv, "d:i:t:u:n:m:o:qfcC:U:Ma:r:sI:p:")) != -1) {
+  while ((opt = getopt(argc, argv, "d:i:D:t:u:n:m:o:qfcC:U:Ma:r:sI:p:")) !=
+         -1) {
     switch (opt) {
-      case 'd' :
+      case 'd':
         DB_filenames.push_back(optarg);
         break;
-      case 'i' :
+      case 'i':
         Index_filenames.push_back(optarg);
         break;
-      case 't' :
+      case 'D':
+        Onefile_DB_filenames.push_back(optarg);
+        break;
+      case 'l':
+        Lock_DB = true;
+        break;
+      case 't':
         sig = atoll(optarg);
         if (sig <= 0)
           errx(EX_USAGE, "can't use nonpositive thread count");
@@ -696,54 +683,58 @@ void parse_command_line(int argc, char **argv) {
         omp_set_num_threads(Num_threads);
         #endif
         break;
-      case 'p' :
+      case 'p':
         HLL_PRECISION = stoi(optarg);
         break;
-      case 'q' :
+      case 'q':
         Quick_mode = true;
         break;
-      case 'm' :
+      case 'm':
         sig = atoll(optarg);
         if (sig <= 0)
           errx(EX_USAGE, "can't use nonpositive minimum hit count");
         Minimum_hit_count = sig;
         break;
-      case 'f' :
+      case 'f':
         Fastq_input = true;
         break;
-      case 'c' :
+      case 'c':
         Only_classified_kraken_output = true;
         break;
-      case 'C' :
+      case 'C':
         Print_classified = true;
-        Classified_output_file = optarg;
+        // Classified_output_file = optarg;
+        Classified_output_files.push_back(optarg);
         break;
-      case 'U' :
+      case 'U':
         Print_unclassified = true;
-        Unclassified_output_file = optarg;
+        // Unclassified_output_file = optarg;
+        Unclassified_output_files.push_back(optarg);
         break;
-      case 'o' :
-        Kraken_output_file = optarg;
+      case 'o':
+        // Kraken_output_file = optarg;
+        Kraken_output_files.push_back(optarg);
         break;
-      case 'r' :
-        Report_output_file = optarg;
+      case 'r':
+        // Report_output_file = optarg;
+        Report_output_files.push_back(optarg);
         break;
-      case 's' :
+      case 's':
         Print_sequence = true;
         break;
-      case 'a' :
+      case 'a':
         TaxDB_file = optarg;
         break;
-      case 'u' :
+      case 'u':
         sig = atoll(optarg);
         if (sig <= 0)
           errx(EX_USAGE, "can't use nonpositive work unit size");
         Work_unit_size = sig;
         break;
-      case 'M' :
+      case 'M':
         Populate_memory = true;
         break;
-      case 'I' :
+      case 'I':
         UID_to_TaxID_map_filename = optarg;
         Map_UIDs = true;
         break;
@@ -753,16 +744,18 @@ void parse_command_line(int argc, char **argv) {
     }
   }
 
-  if (DB_filenames.empty()) {
-    cerr << "Missing mandatory option -d" << endl;
-    usage();
-  }
-  if (Index_filenames.empty()) {
-    cerr << "Missing mandatory option -i" << endl;
-    usage();
-  }
-  if (optind == argc && !Populate_memory) {
-    cerr << "No sequence data files specified" << endl;
+  if (Onefile_DB_filenames.empty()) {
+    if (DB_filenames.empty()) {
+      cerr << "Missing mandatory option -d" << endl;
+      usage();
+    }
+    if (Index_filenames.empty()) {
+      cerr << "Missing mandatory option -i" << endl;
+      usage();
+    }
+    if (optind == argc && !Populate_memory) {
+      cerr << "No sequence data files specified" << endl;
+    }
   }
 }
 
@@ -772,11 +765,15 @@ void usage(int exit_code) {
        << "Options: (*mandatory)" << endl
        << "* -d filename      Kraken DB filename" << endl
        << "* -i filename      Kraken DB index filename" << endl
+       << "  -D filename      Kraken DB stored in a single file" << endl
        << "  -o filename      Output file for Kraken output" << endl
        << "  -r filename      Output file for Kraken report output" << endl
        << "  -a filename      TaxDB" << endl
        << "  -I filename      UID to TaxId map" << endl
-       << "  -p #             Precision for unique k-mer counting, between 10 and 18" << endl
+       << "  -l               Memory lock DB files" << endl
+       << "  -p #             Precision for unique k-mer counting, between 10 "
+    "and 18"
+       << endl
        << "  -t #             Number of threads" << endl
        << "  -u #             Thread work unit size (in bp)" << endl
        << "  -q               Quick operation" << endl

--- a/src/krakenutil.cpp
+++ b/src/krakenutil.cpp
@@ -21,12 +21,51 @@
 #include "assert_helpers.h"
 #include "kraken_headers.hpp"
 #include "krakenutil.hpp"
+#include "gzstream.h"
 #include <unordered_set>
 #include<algorithm>
 
 using namespace std;
 
 namespace kraken {
+
+  inline bool ends_with(std::string const & value, std::string const & ending)
+  {
+    if (ending.size() > value.size()) return false;
+    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+  }
+
+  managed_ostream::managed_ostream() : s() {}
+  managed_ostream::managed_ostream(ostream* managed_ostream) : s(managed_ostream) {}
+  managed_ostream::managed_ostream(const string& file, bool use, bool append) {
+    if (!use || file.empty()) {
+      s = nullptr;
+    } else if (file == "-") {
+      s = &cout;
+    } else if (ends_with(file, ".gz")) {
+      s = new ogzstream(file.c_str());
+      s->exceptions(ifstream::failbit | ifstream::badbit);
+    } else {
+      s = append ? new ofstream(file.c_str(), std::ofstream::app)
+        : new ofstream(file.c_str());
+      s->exceptions(ifstream::failbit | ifstream::badbit);
+    }
+  }
+  managed_ostream::~managed_ostream()
+  {
+    if (s && s->rdbuf() != std::cout.rdbuf()) {
+      delete s;
+    }
+  }
+  ostream& managed_ostream::operator* ()
+  {
+    return *s;
+  }
+
+  ostream* managed_ostream::operator-> ()
+  {
+    return s;
+  }
 
   // Build a node->parent unordered_map from NCBI Taxonomy nodes.dmp file
   unordered_map<uint32_t, uint32_t> build_parent_map(string filename) {

--- a/src/krakenutil.hpp
+++ b/src/krakenutil.hpp
@@ -28,12 +28,27 @@ namespace kraken {
   // Build a map of node to parent from an NCBI taxonomy nodes.dmp file
   std::unordered_map<uint32_t, uint32_t> build_parent_map(std::string filename);
 
-  // Return lowest common ancestor of a and b
-  // LCA(0,x) = LCA(x,0) = x
-  // Default ancestor is 1 (root of tree)
-uint32_t lca(const std::unordered_map<uint32_t, uint32_t> &parent_map, uint32_t a, uint32_t b);
+    // Return lowest common ancestor of a and b
+    // LCA(0,x) = LCA(x,0) = x
+    // Default ancestor is 1 (root of tree)
+  uint32_t lca(const std::unordered_map<uint32_t, uint32_t> &parent_map, uint32_t a, uint32_t b);
+  inline bool ends_with(std::string const &value, std::string const &ending);
 
+  class managed_ostream {
+  public:
+    managed_ostream &operator=(const managed_ostream &) = delete;
+    managed_ostream(const managed_ostream &) = delete;
 
+    managed_ostream();
+    managed_ostream(std::ostream *managed_ostream);
+    managed_ostream(const std::string &file, bool use = true, bool append = false);
+    ~managed_ostream();
+    std::ostream &operator*();
+    std::ostream *operator->();
+
+  private:
+    std::ostream *s;
+  };
 
   // Resolve classification tree
   uint32_t resolve_tree(const std::unordered_map<uint32_t, uint32_t> &hit_counts,

--- a/src/taxdb.hpp
+++ b/src/taxdb.hpp
@@ -261,6 +261,7 @@ class TaxonomyDB {
 
     void setGenomeSizes(const std::unordered_map<TAXID, uint64_t> & genomeSizes);
     void readGenomeSizes(string file);
+    void readGenomeSizes(istream& buf);
     void setGenomeSize(const TAXID taxid, const uint64_t genomeSize);
 
     void printReport();
@@ -883,6 +884,18 @@ void TaxonomyDB<TAXID>::readGenomeSizes(string file) {
 
   cerr << " done" << endl;
 }
+
+template<typename TAXID>
+void TaxonomyDB<TAXID>::readGenomeSizes(istream& buf) {
+  TAXID taxonomyID;
+  uint64_t size;
+  while (!buf.eof()) {
+    buf >> taxonomyID >> size;
+    setGenomeSize(taxonomyID, size);
+  }
+  cerr << " done" << endl;
+}
+
 
 /*
    template<typename TAXID>


### PR DESCRIPTION
Normally the output is in shuffled blocks due to random OpenMP ordering. Use the ordered pragma of
OpenMP for ordered output (incurs a performance penalty for synch).