### PR TITLE
Use more portable way to access own args

### DIFF
--- a/scripts/krakenuniq
+++ b/scripts/krakenuniq
@@ -230,7 +230,7 @@ if ($paired) {
 my $cmd = $use_exact_counting? $CLASSIFY_EXACT : $CLASSIFY;
 print STDERR "$cmd @flags\n";
 if (defined $report_file) {
-    my $mycmd = qx/ps -o args= $$/;
+    my $mycmd = 'krakenuniq ' . join(' ', @ARGS);
     open(my $RF, ">", $report_file) or die "Could not open report file for writing";
     print $RF "# KrakenUniq v#####=VERSION=##### DATE:$date DB:@db_prefix DB_SIZE:$db_size WD:$wd\n# CL:$mycmd\n";
     close($RF)


### PR DESCRIPTION
https://github.com/fbreitwieser/krakenuniq/blob/master/scripts/krakenuniq#L233

In containerized applications, 'ps' will often be provided not by the procps package, but by Busybox,
which doesn't fully support the same options; here, this will result in garbled output of the `krakenuniq`
script.

I've adapted the code to rely on perl exclusively instead of invoking an external `ps` at all.