### PR TITLE
Generate command line for report without external call to ps

### DIFF
--- a/scripts/krakenuniq
+++ b/scripts/krakenuniq
@@ -68,6 +68,7 @@ my $print_sequence = 0;
 my $uid_mapping = 0;
 my $hll_precision = 12;
 my $use_exact_counting = 0;
+my @cmdline = @ARGV;
 
 GetOptions(
   "help" => \&display_help,
@@ -230,7 +231,7 @@ if ($paired) {
 my $cmd = $use_exact_counting? $CLASSIFY_EXACT : $CLASSIFY;
 print STDERR "$cmd @flags\n";
 if (defined $report_file) {
-    my $mycmd = qx/ps -o args= $$/;
+    my $mycmd = join(' ', $0, @cmdline);
     open(my $RF, ">", $report_file) or die "Could not open report file for writing";
     print $RF "# KrakenUniq v#####=VERSION=##### DATE:$date DB:@db_prefix DB_SIZE:$db_size WD:$wd\n# CL:$mycmd\n";
     close($RF)


### PR DESCRIPTION
An improvement of the suggestion in #116 
I originally discovered this issue when trying to run KrakenUniq with the Biocontainer built from the conda releases (in this case the container with tag `1.0.0--pl5321h19e8d03_0`) where the version of `ps` used apparently doesn't support the same command line arguments as were used in the original report generation code to produce a string with the command line used to call krakenuniq. 

Here are examples of the command lines of the report:
## Original code
```
# CL:perl /ceph/home/boulund/work/stag-uniq/.snakemake/conda/207ba047bd7ea05bc7d1265affc0c46c/bin/krakenuniq --db /ceph/db/krakenuniq/minikraken_20171013_4GB --threads 4 --output output_dir/krakenuniq/test1.kraken.gz --report-file output_dir/krakenuniq/test1.kreport --paired output_dir/host_removal/test1_1.fq.gz output_dir/host_removal/test1_2.fq.gz

```

## This PR
```
# CL:/ceph/home/boulund/work/stag-uniq/.snakemake/conda/207ba047bd7ea05bc7d1265affc0c46c/bin/krakenuniq --db /ceph/db/krakenuniq/minikraken_20171013_4GB --threads 4 --output output_dir/krakenuniq/test1.kraken.gz --report-file output_dir/krakenuniq/test1.kreport --preload-size 2G --paired output_dir/host_removal/test1_1.fq.gz output_dir/host_removal/test1_2.fq.gz
```

I know the initial `perl` isn't included, but it's easy to add if you find it important to keep. 