### PR TITLE
Fix: Add "file" to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache \
   make \
   g++ \
   bzip2-dev \
-  zlib-dev
+  zlib-dev \
+  file
 
 WORKDIR /app
 COPY . . 


### PR DESCRIPTION
KrakenUniq script `read_merger.pl` does not work as intended if `file` is not present in the execution environment, which leads to empty report files because input data could not be processed and KrakenUniq does not exit when this happens which unfortunately masks this error.

https://github.com/fbreitwieser/krakenuniq/issues/130